### PR TITLE
Follow updates of fisherman/fzf

### DIFF
--- a/functions/__ghq_crtl_g.fish
+++ b/functions/__ghq_crtl_g.fish
@@ -2,7 +2,7 @@ function __ghq_crtl_g -d 'Repository search'
     set -l selector
     [ -z "$GHQ_SELECTOR" ]; and set selector fzf; or set selector $GHQ_SELECTOR
     if [ "$selector" = fzf ]
-        functions -q __fzfcmd; and set selector __fzfcmd
+        functions -q __fzfcmd; and set selector (__fzfcmd)
     end
     set -l query (commandline -b)
     [ -n "$query" ]; and set flags --query="$query"; or set flags


### PR DESCRIPTION
fisherman/fzf has been updated and the `__fzfcmd` function now returns string.

https://github.com/fisherman/fzf/commit/e945089d4cb167581a2f0bd16870aeec1ecfd44d#diff-9558046929d8a96a32a994a0eb71246d

Therefore, if the __fzfcmd function is defined, modification has been made so that evaluation is performed once before being stored in variable `$selector`.