### PR TITLE
Use "2>" to redirect stderr instead of the deprecated "^"

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,4 +1,4 @@
 bind \cg '__ghq_crtl_g'
-if bind -M insert >/dev/null ^/dev/null
+if bind -M insert >/dev/null 2>/dev/null
     bind -M insert \cg '__ghq_crtl_g'
 end


### PR DESCRIPTION
See this GH issue for more information:

https://github.com/fish-shell/fish-shell/issues/4394

I have the feature enabled which disables caret-as-stderr-redirect (`set -U fish_features stderr-nocaret`). With this set, installing fish-ghq results in:
```
bind: No binding found for sequence '^/dev/null'
```
being printed after starting my shell.