### PR TITLE
add support for skim

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ completions and keybinding for [ghq]
 ## Install
 
 * Install [ghq]
-* Install [fzf], [fzy], [peco] or [percol]
+* Install [fzf], [fzy], [peco], [percol] or [skim]
 * Install [Fisher](https://github.com/jorgebucaran/fisher)
 * Install this plugin
 
@@ -19,7 +19,7 @@ fisher add decors/fish-ghq
 
 ## Keybinding
 
-* Ctrl-g: repository finder using [fzf], [fzy], [peco] or [percol].
+* Ctrl-g: repository finder using [fzf], [fzy], [peco], [percol] or [skim].
 
 ## Variables
 
@@ -28,7 +28,7 @@ fisher add decors/fish-ghq
 Default selector is `fzf`. If you want to change selector, run
 
 ```fish
-set -g GHQ_SELECTOR peco (or fzf, fzf-tmux, fzy, percol)
+set -g GHQ_SELECTOR peco (or fzf, fzf-tmux, fzy, percol, skim)
 ```
 
 ### `GHQ_SELECTOR_OPTS`
@@ -68,3 +68,4 @@ fish-ghq is MIT licensed. See [LICENSE](LICENSE) file for details.
 [fzf]:https://github.com/junegunn/fzf
 [fzy]:https://github.com/jhawthorn/fzy
 [percol]:https://github.com/mooz/percol
+[skim]:https://github.com/lotabout/skim

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ fisher add decors/fish-ghq
 Default selector is `fzf`. If you want to change selector, run
 
 ```fish
-set -g GHQ_SELECTOR peco (or fzf, fzf-tmux, fzy, percol, skim)
+set -g GHQ_SELECTOR peco (or fzf, fzf-tmux, fzy, percol, sk)
 ```
 
 ### `GHQ_SELECTOR_OPTS`

--- a/functions/__ghq_repository_search.fish
+++ b/functions/__ghq_repository_search.fish
@@ -12,7 +12,7 @@ function __ghq_repository_search -d 'Repository search'
     set -l query (commandline -b)
     [ -n "$query" ]; and set flags --query="$query"; or set flags
     switch "$selector"
-        case fzf fzf-tmux peco percol fzy skim
+        case fzf fzf-tmux peco percol fzy sk
             ghq list --full-path | eval "$selector" $selector_options $flags | read select
         case \*
             printf "\nERROR: plugin-ghq is not support '$selector'.\n"

--- a/functions/__ghq_repository_search.fish
+++ b/functions/__ghq_repository_search.fish
@@ -12,7 +12,7 @@ function __ghq_repository_search -d 'Repository search'
     set -l query (commandline -b)
     [ -n "$query" ]; and set flags --query="$query"; or set flags
     switch "$selector"
-        case fzf fzf-tmux peco percol fzy
+        case fzf fzf-tmux peco percol fzy skim
             ghq list --full-path | eval "$selector" $selector_options $flags | read select
         case \*
             printf "\nERROR: plugin-ghq is not support '$selector'.\n"


### PR DESCRIPTION
This PR adds support for [skim](https://github.com/lotabout/skim).
Skim is an alternative of `fzf`, written in Rust and with a new fuzzy-search algorithm.

This PR just allows user to select `skim`, and shows it in the Readme :)

thanks!