### PR TITLE
fix freeze bug on fish 3.1.0

### DIFF
--- a/functions/__ghq_repository_search.fish
+++ b/functions/__ghq_repository_search.fish
@@ -13,7 +13,7 @@ function __ghq_repository_search -d 'Repository search'
     [ -n "$query" ]; and set flags --query="$query"; or set flags
     switch "$selector"
         case fzf fzf-tmux peco percol fzy sk
-            ghq list --full-path | eval "$selector" $selector_options $flags | read select
+            ghq list --full-path | "$selector" $selector_options $flags | read select
         case \*
             printf "\nERROR: plugin-ghq is not support '$selector'.\n"
     end


### PR DESCRIPTION
This PR fixes freeze bug on fish 3.1.0 on Ubuntu. This bug was reproduced in the following environment:
- os: ubuntu18.04
- shell: fish 3.1.0
- selector: ghq 1.1.0 and fzf 0.21.0