### PR TITLE
Improve nonexistent selector

### DIFF
--- a/functions/__ghq_repository_search.fish
+++ b/functions/__ghq_repository_search.fish
@@ -6,7 +6,7 @@ function __ghq_repository_search -d 'Repository search'
 
     if not type -qf $selector
         printf "\nERROR: '$selector' not found.\n"
-        exit 1
+        return 1
     end
 
     set -l query (commandline -b)


### PR DESCRIPTION
If set nonexistent command to selector and type Ctrl+g, fish exits.

For example

```
$ set -g GHQ_SELECTOR invalidcommand
```

and type Ctrl+g

Change this behavior to return function

I tested with fish version 3.1.2