### PR TITLE
Distinct paths by awk

### DIFF
--- a/functions/__ghq_repository_search.fish
+++ b/functions/__ghq_repository_search.fish
@@ -13,7 +13,7 @@ function __ghq_repository_search -d 'Repository search'
     [ -n "$query" ]; and set flags --query="$query"; or set flags
     switch "$selector"
         case fzf fzf-tmux peco percol fzy sk
-            ghq list --full-path | "$selector" $selector_options $flags | read select
+            ghq list --full-path | awk '!x[$0]++' | "$selector" $selector_options $flags | read select
         case \*
             printf "\nERROR: plugin-ghq is not support '$selector'.\n"
     end


### PR DESCRIPTION
since ghq may generate multiple paths if gitconfig has couple definitions like
```
[ghq]
	root = ~/Repositories
[ghq "https://git.xxx.xxx"]
	root = ~/Repositories/Work/git.xxx.xxx
```

so this PR makes it unique when passing paths to fuzzy finders (I also try to find the option to distinct on fuzzy finders but fzf doesn't support it https://github.com/junegunn/fzf/issues/270 therefore I made this changes)